### PR TITLE
fetch returns a Headers object that exposes get method

### DIFF
--- a/levels/programmable_voice/objectives/voice4/validator.js
+++ b/levels/programmable_voice/objectives/voice4/validator.js
@@ -32,7 +32,7 @@ module.exports = async function(helper) {
         response.status
       }.`;
     }
-    const contentType = response.headers['content-type'];
+    const contentType = response.headers.get('Content-Type');
     if (!contentType.toLowerCase().startsWith('audio')) {
       throw `Oh no, it looks like ${audioUrl} is not an audio file. It is of type "${contentType}"`;
     }


### PR DESCRIPTION
The switch from using `got` to `fetch` means the headers object returned works a little differently and no longer lowercases the keys.

This is the only use of headers in this extension.

Tested locally and `toLowerCase` bug is no longer present.